### PR TITLE
Fixed Textarea Resizing Bug

### DIFF
--- a/js/forms.js
+++ b/js/forms.js
@@ -144,14 +144,31 @@
         hiddenDiv.css('width', $(window).width()/2);
       }
 
-      $textarea.css('height', hiddenDiv.height());
+      /**
+       * Resize if the new height is greater than the
+       * original height of the textarea
+       */
+      if($textarea.data("original-height") <= hiddenDiv.height()){
+        $textarea.css('height', hiddenDiv.height());
+      }else if($textarea.val().length < $textarea.data("previous-length")){
+        /**
+         * In case the new height is less than original height, it
+         * means the textarea has less text than before
+         * So we set the height to the original one
+         */
+        $textarea.css('height', $textarea.data("original-height"));
+      }
+      $textarea.data("previous-length", $textarea.val().length);
     }
 
     $(text_area_selector).each(function () {
       var $textarea = $(this);
-      if ($textarea.val().length) {
-        textareaAutoResize($textarea);
-      }
+      /**
+       * Instead of resizing textarea on document load,
+       * store the original height and the original length
+       */
+      $textarea.data("original-height", $textarea.height());
+      $textarea.data("previous-length", $textarea.val().length);
     });
 
     $('body').on('keyup keydown autoresize', text_area_selector, function () {


### PR DESCRIPTION
Currently, Materialize resizes textarea on document load. What if I want to set a **default height** to textarea and when the text overflows that height, textarea should resize. Also, when the content becomes null again, textarea should resize to the **default height** instead.

Instead of setting the height of textarea default on document load, MZ should store the height and then resize textarea according to the length and the original height of the textarea.
